### PR TITLE
Provide Markdown support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "jade": "0.27.6",
     "stylus": "0.29.0",
     "restler": "2.0.1",
-    "walk": "2.2.1"
+    "walk": "2.2.1",
+    "markdown": "1.1.65"
   },
   "bin": {
     "proto": "./bin/proto"


### PR DESCRIPTION
Included [markdown.js](https://github.com/evilstreak/markdown-js) as a requirement, enabling the `:markdown` filter to be used in `markup.jade`.
